### PR TITLE
feat: add texture map parameter control and textures API

### DIFF
--- a/apps/api/src/routes/assets.ts
+++ b/apps/api/src/routes/assets.ts
@@ -9,6 +9,7 @@ export interface AssetStoreLike {
 
 export interface AssetsRouterDeps {
   assetStore?: AssetStoreLike;
+  textureStore?: AssetStoreLike;
   signUrl?: (assetUrl: string) => Promise<string>;
 }
 
@@ -50,6 +51,7 @@ async function signAssetUrl(assetUrl: string): Promise<string> {
 export function createAssetsRouter(deps: AssetsRouterDeps = {}): Router {
   const router = Router();
   const assetStore = deps.assetStore || getDefaultAssetStore();
+  const textureStore = deps.textureStore || assetStore;
   const signer = deps.signUrl || signAssetUrl;
 
   router.get('/:assetId', async (req: Request, res: Response) => {
@@ -68,6 +70,18 @@ export function createAssetsRouter(deps: AssetsRouterDeps = {}): Router {
     };
 
     res.json(response);
+  });
+
+  router.get('/:assetId/textures', async (req: Request, res: Response) => {
+    const { assetId } = req.params;
+    const texturesJson = await textureStore.get(`textures:${assetId}`);
+
+    if (!texturesJson) {
+      res.status(404).json({ error: 'Textures not found' });
+      return;
+    }
+
+    res.json(JSON.parse(texturesJson));
   });
 
   router.get('/:assetId/preview', async (req: Request, res: Response) => {

--- a/apps/api/test/assets-textures.test.ts
+++ b/apps/api/test/assets-textures.test.ts
@@ -1,0 +1,73 @@
+import request from 'supertest';
+import { describe, expect, it, vi } from 'vitest';
+import { createApp } from '../src/app';
+import { AssetStoreLike } from '../src/routes/assets';
+
+function createQueueMock() {
+  return {
+    add: vi.fn().mockResolvedValue(undefined),
+    getJob: vi.fn().mockResolvedValue(null),
+  };
+}
+
+function createStore(seed: Record<string, string> = {}): AssetStoreLike {
+  const map = new Map(Object.entries(seed));
+  return {
+    get: vi.fn(async (key: string) => map.get(key) ?? null),
+    set: vi.fn(async (key: string, value: string) => { map.set(key, value); }),
+  };
+}
+
+describe('GET /v1/assets/:id/textures', () => {
+  it('returns texture map URLs when textures exist', async () => {
+    const textures = { albedo: 'https://cdn.meshy.ai/albedo.png', normal: 'https://cdn.meshy.ai/normal.png' };
+    const textureStore = createStore({ 'textures:asset-1': JSON.stringify(textures) });
+    const assetStore = createStore({ 'asset:asset-1': 'https://cdn.example.com/model.glb' });
+
+    const app = createApp(createQueueMock(), {
+      includeHistory: false,
+      saveToHistory: vi.fn().mockResolvedValue(undefined),
+      assets: { assetStore, textureStore },
+    });
+
+    const res = await request(app).get('/v1/assets/asset-1/textures');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(textures);
+  });
+
+  it('returns 404 when textures are not found', async () => {
+    const textureStore = createStore();
+    const assetStore = createStore();
+
+    const app = createApp(createQueueMock(), {
+      includeHistory: false,
+      saveToHistory: vi.fn().mockResolvedValue(undefined),
+      assets: { assetStore, textureStore },
+    });
+
+    const res = await request(app).get('/v1/assets/missing/textures');
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Textures not found');
+  });
+
+  it('returns all four texture map types when present', async () => {
+    const textures = {
+      albedo: 'https://cdn.meshy.ai/albedo.png',
+      normal: 'https://cdn.meshy.ai/normal.png',
+      roughness: 'https://cdn.meshy.ai/roughness.png',
+      metallic: 'https://cdn.meshy.ai/metallic.png',
+    };
+    const textureStore = createStore({ 'textures:asset-full': JSON.stringify(textures) });
+    const assetStore = createStore();
+
+    const app = createApp(createQueueMock(), {
+      includeHistory: false,
+      saveToHistory: vi.fn().mockResolvedValue(undefined),
+      assets: { assetStore, textureStore },
+    });
+
+    const res = await request(app).get('/v1/assets/asset-full/textures');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(textures);
+  });
+});

--- a/apps/web/src/components/TexturePanel.tsx
+++ b/apps/web/src/components/TexturePanel.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+interface TextureMaps {
+  albedo?: string;
+  normal?: string;
+  roughness?: string;
+  metallic?: string;
+}
+
+interface TexturePanelProps {
+  textures: TextureMaps;
+}
+
+const TEXTURE_LABELS: { key: keyof TextureMaps; label: string }[] = [
+  { key: 'albedo', label: 'Albedo' },
+  { key: 'normal', label: 'Normal' },
+  { key: 'roughness', label: 'Roughness' },
+  { key: 'metallic', label: 'Metallic' },
+];
+
+export default function TexturePanel({ textures }: TexturePanelProps) {
+  return (
+    <div style={{ marginTop: '1rem' }}>
+      <h4 style={{ marginBottom: '0.5rem' }}>Texture Maps</h4>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '0.5rem' }}>
+        {TEXTURE_LABELS.map(({ key, label }) => (
+          <div key={key} style={{ textAlign: 'center' }}>
+            <div style={{ fontSize: '0.75rem', marginBottom: '0.25rem', color: '#666' }}>{label}</div>
+            {textures[key] ? (
+              <img
+                src={textures[key]}
+                alt={label}
+                style={{ width: '100%', aspectRatio: '1', objectFit: 'cover', borderRadius: '4px', border: '1px solid #ddd' }}
+              />
+            ) : (
+              <div style={{ width: '100%', aspectRatio: '1', background: '#f0f0f0', borderRadius: '4px', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '0.75rem', color: '#999' }}>
+                N/A
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -52,6 +52,11 @@ const worker = new Worker<JobData, JobReturn>(
     // Store asset URL in Redis
     await redis.set(`${ASSET_PREFIX}${result.assetId}`, result.assetUrl);
 
+    // Store texture map URLs in Redis if available
+    if (result.textureMapIds && Object.keys(result.textureMapIds).length > 0) {
+      await redis.set(`textures:${result.assetId}`, JSON.stringify(result.textureMapIds));
+    }
+
     console.log(`Job ${job.id} completed, asset: ${result.assetId}`);
 
     return result;

--- a/apps/worker/src/providers/hunyuan.ts
+++ b/apps/worker/src/providers/hunyuan.ts
@@ -436,6 +436,10 @@ async function generate(job: Job<JobData, ProviderResult>, ctx: ProviderContext)
     throw new Error('Hunyuan credentials are not configured');
   }
 
+  if (job.data.textureOptions) {
+    console.warn('[Hunyuan] textureOptions are not supported by Hunyuan provider; ignoring');
+  }
+
   let useImageBase64 = config.imageInputMode === 'base64';
   let jobId = await submitJob(job, config, { useImageBase64 });
   let result = await pollJob(jobId, config);

--- a/apps/worker/src/providers/provider.ts
+++ b/apps/worker/src/providers/provider.ts
@@ -10,6 +10,7 @@ export interface ProviderContext {
 export interface ProviderResult {
   assetId: string;
   assetUrl: string;
+  textureMapIds?: Record<string, string>;
 }
 
 export interface ProviderAdapter {

--- a/apps/worker/test/providers/meshy-texture.test.ts
+++ b/apps/worker/test/providers/meshy-texture.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { buildTextTaskPayload, buildImageTaskPayload, buildMultiViewTaskPayload } from '../../src/providers/meshy';
+import { TextureStyle } from '@ai-3d-platform/shared';
+
+describe('meshy textureOptions mapping', () => {
+  describe('buildTextTaskPayload with textureOptions', () => {
+    it('includes texture_resolution and art_style when textureOptions provided', () => {
+      const payload = buildTextTaskPayload('a red car', { resolution: 1024, style: TextureStyle.Photorealistic });
+      expect(payload.texture_resolution).toBe(1024);
+      expect(payload.art_style).toBe('realistic');
+    });
+
+    it('omits texture fields when no textureOptions', () => {
+      const payload = buildTextTaskPayload('a red car');
+      expect(payload.texture_resolution).toBeUndefined();
+      expect(payload.art_style).toBeUndefined();
+    });
+
+    it('maps Cartoon style to cartoon', () => {
+      const payload = buildTextTaskPayload('a toy', { resolution: 512, style: TextureStyle.Cartoon });
+      expect(payload.art_style).toBe('cartoon');
+    });
+
+    it('maps Stylized style to low-poly', () => {
+      const payload = buildTextTaskPayload('a toy', { resolution: 512, style: TextureStyle.Stylized });
+      expect(payload.art_style).toBe('low-poly');
+    });
+
+    it('maps Flat style to pbr', () => {
+      const payload = buildTextTaskPayload('a toy', { resolution: 2048, style: TextureStyle.Flat });
+      expect(payload.art_style).toBe('pbr');
+      expect(payload.texture_resolution).toBe(2048);
+    });
+  });
+
+  describe('buildImageTaskPayload with textureOptions', () => {
+    it('includes texture_resolution and art_style when textureOptions provided', () => {
+      const payload = buildImageTaskPayload('https://example.com/img.png', { resolution: 2048, style: TextureStyle.Cartoon });
+      expect(payload.texture_resolution).toBe(2048);
+      expect(payload.art_style).toBe('cartoon');
+    });
+
+    it('omits texture fields when no textureOptions', () => {
+      const payload = buildImageTaskPayload('https://example.com/img.png');
+      expect(payload.texture_resolution).toBeUndefined();
+      expect(payload.art_style).toBeUndefined();
+    });
+  });
+
+  describe('buildMultiViewTaskPayload with textureOptions', () => {
+    const viewImages = {
+      front: 'https://example.com/front.png',
+      left: 'https://example.com/left.png',
+      right: 'https://example.com/right.png',
+    };
+
+    it('includes texture_resolution and art_style when textureOptions provided', () => {
+      const payload = buildMultiViewTaskPayload(viewImages, { resolution: 1024, style: TextureStyle.Stylized });
+      expect(payload.texture_resolution).toBe(1024);
+      expect(payload.art_style).toBe('low-poly');
+    });
+
+    it('omits texture fields when no textureOptions', () => {
+      const payload = buildMultiViewTaskPayload(viewImages);
+      expect(payload.texture_resolution).toBeUndefined();
+      expect(payload.art_style).toBeUndefined();
+    });
+  });
+});

--- a/packages/shared/src/enums.ts
+++ b/packages/shared/src/enums.ts
@@ -49,3 +49,13 @@ export enum Provider {
   Hunyuan = 'hunyuan',
   Meshy = 'meshy',
 }
+
+/**
+ * Texture style enum
+ */
+export enum TextureStyle {
+  Photorealistic = 'photorealistic',
+  Cartoon = 'cartoon',
+  Stylized = 'stylized',
+  Flat = 'flat',
+}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,4 +1,12 @@
-import { JobStatus, JobType, AssetFormat, UserRole, AuthProvider, Provider } from './enums';
+import { JobStatus, JobType, AssetFormat, UserRole, AuthProvider, Provider, TextureStyle } from './enums';
+
+/**
+ * Texture generation options
+ */
+export interface TextureOptions {
+  resolution: 512 | 1024 | 2048;
+  style: TextureStyle;
+}
 
 export interface MultiViewImages {
   front: string;
@@ -15,6 +23,7 @@ export interface CreateJobRequest {
   imageUrl?: string;
   viewImages?: MultiViewImages;
   provider?: Provider;
+  textureOptions?: TextureOptions;
 }
 
 /**
@@ -53,6 +62,7 @@ export interface JobData {
   imageUrl?: string;
   viewImages?: MultiViewImages;
   provider?: Provider;
+  textureOptions?: TextureOptions;
   createdAt: number;
 }
 
@@ -65,6 +75,7 @@ export interface JobResult {
   format: AssetFormat;
   provider: string;
   generationTimeMs: number;
+  textureMapIds?: Record<string, string>;
 }
 
 /**

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,70 @@
+# feature/texture-maps 实施清单
+
+## 目标
+为 3D 生成平台添加纹理贴图参数控制和独立贴图 API。
+
+## 任务清单
+
+### 阶段 1：类型定义
+- [x] `packages/shared/src/enums.ts` — 新增 `TextureStyle` 枚举（Photorealistic/Cartoon/Stylized/Flat）
+- [x] `packages/shared/src/types.ts` — 新增 `TextureOptions` 接口（resolution: 512|1024|2048, style: TextureStyle）
+- [x] `packages/shared/src/types.ts` — `CreateJobRequest` 增加 `textureOptions?: TextureOptions`
+- [x] `packages/shared/src/types.ts` — `JobResult` 增加 `textureMapIds?: Record<string, string>`
+
+### 阶段 2：API 层
+- [x] `apps/api/src/routes/jobs.ts` — 更新 Zod schema 验证 textureOptions
+- [x] `apps/api/src/routes/assets.ts` — 新增 `GET /v1/assets/:assetId/textures` 路由
+  - 查 Redis: `textures:{assetId}`
+  - 返回 `{ albedo?, normal?, roughness?, metallic? }` 各自的 downloadUrl
+
+### 阶段 3：Worker Provider
+- [x] `apps/worker/src/providers/meshy.ts` — 传入 textureOptions
+  - resolution → `texture_resolution`
+  - style → `art_style`（realistic/cartoon/low-poly/pbr）
+  - 任务完成后解析 `result.textures`，分别存储贴图
+- [x] `apps/worker/src/providers/hunyuan.ts` — 若不支持则记录 warn，忽略
+- [x] `apps/worker/src/index.ts` — 处理 textureMapIds，写入 Redis `textures:{assetId}`
+
+### 阶段 4：测试
+- [x] `apps/api/test/assets-textures.test.ts` — GET /v1/assets/:id/textures 路由测试（mock Redis）
+- [x] `apps/worker/test/providers/meshy-texture.test.ts` — textureOptions 映射到 payload 测试
+- [x] 运行 `pnpm test:all` 全绿
+
+### 阶段 5：Web UI
+- [x] `apps/web/src/components/TexturePanel.tsx` — 新组件，展示 4 张贴图缩略图
+- [x] `apps/web/src/app/page.tsx` — 增加 TextureOptions 表单（resolution 下拉 + style 选择）
+- [x] `apps/web/src/app/page.tsx` — 成功后渲染 TexturePanel
+
+## 验证
+```bash
+pnpm test:worker   # meshy-texture.test.ts 全绿 ✅ 28 tests passed
+pnpm test:api      # assets-textures.test.ts 全绿 ✅ 20 tests passed
+pnpm test:all      # 全套通过 ✅ including 2 smoke tests
+```
+
+## 完成标准
+- [x] API 接受 textureOptions 并通过验证
+- [x] GET /v1/assets/:id/textures 返回各贴图 URL
+- [x] Meshy provider 正确传递纹理参数
+- [x] 所有单元/集成测试通过（`pnpm test:all`）
+- [ ] PR 提交到 master，AI review 通过
+
+## Review
+
+所有 5 个阶段已完成。改动清单：
+
+### 新增文件
+- `apps/api/test/assets-textures.test.ts` — 3 tests for textures endpoint
+- `apps/worker/test/providers/meshy-texture.test.ts` — 9 tests for textureOptions mapping
+- `apps/web/src/components/TexturePanel.tsx` — 4-slot texture thumbnail grid
+
+### 修改文件
+- `packages/shared/src/enums.ts` — `TextureStyle` enum
+- `packages/shared/src/types.ts` — `TextureOptions`, updated `CreateJobRequest`, `JobData`, `JobResult`
+- `apps/api/src/routes/jobs.ts` — Zod schema validation for textureOptions
+- `apps/api/src/routes/assets.ts` — GET /:assetId/textures route + textureStore dep
+- `apps/worker/src/providers/provider.ts` — `ProviderResult.textureMapIds?`
+- `apps/worker/src/providers/meshy.ts` — style mapper, updated payload builders, texture extraction
+- `apps/worker/src/providers/hunyuan.ts` — warn log for unsupported textureOptions
+- `apps/worker/src/index.ts` — Redis write for textures:{assetId}
+- `apps/web/src/app/page.tsx` — TextureOptions form + TexturePanel render


### PR DESCRIPTION
## Summary

- **Shared types**: Add `TextureStyle` enum (`photorealistic/cartoon/stylized/flat`) and `TextureOptions` interface (`resolution: 512|1024|2048, style: TextureStyle`); extend `CreateJobRequest`, `JobData`, and `JobResult`
- **API**: Validate `textureOptions` in `POST /v1/jobs` via Zod; add `GET /v1/assets/:id/textures` endpoint that returns `{ albedo?, normal?, roughness?, metallic? }` URLs from Redis
- **Worker/Meshy**: Map `textureOptions` to `texture_resolution` + `art_style` in all three payload builders; extract `texture_urls` from Meshy response and return as `textureMapIds`; persist to Redis as `textures:{assetId}`
- **Worker/Hunyuan**: Log warn and ignore unsupported `textureOptions`
- **Web UI**: Enable-textures checkbox with resolution/style selectors; `TexturePanel` component renders 4 texture thumbnails on job success

## Test plan

- [x] `pnpm test:worker` — 28 tests pass (includes 9 new `meshy-texture.test.ts` cases)
- [x] `pnpm test:api` — 20 tests pass (includes 3 new `assets-textures.test.ts` cases)
- [x] `pnpm test:all` — full suite green including 2 smoke tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)